### PR TITLE
:sparkles: Token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MyNotif with Django
 
-[![Tests](https://github.com/issa-diallo/Mynotif_backend/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/issa-diallo/Mynotif_backend/actions/workflows/tests.yml)
+[![Tests](https://github.com/issa-diallo/Mynotif_backend/actions/workflows/tests.yml/badge.svg)](https://github.com/issa-diallo/Mynotif_backend/actions/workflows/tests.yml)
 
 ## URLs
 

--- a/src/project_nursing/settings.py
+++ b/src/project_nursing/settings.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     "drf_yasg",
     "nurse",
     "rest_framework",
+    "rest_framework.authtoken",
     "django_on_heroku",
     "django_extensions",
     "corsheaders",
@@ -140,6 +141,15 @@ STATIC_URL = "/static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 CORS_ALLOWED_ORIGINS = json.loads(os.environ.get("CORS_ALLOWED_ORIGINS", "[]"))
+
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": [
+        "rest_framework.permissions.IsAuthenticatedOrReadOnly",
+    ],
+}
 
 if not DEBUG:
     django_on_heroku.settings(locals())

--- a/src/project_nursing/tests.py
+++ b/src/project_nursing/tests.py
@@ -1,6 +1,9 @@
+import pytest
+from django.contrib.auth.models import User
 from django.test import Client
 from django.urls.base import reverse_lazy
 from rest_framework import status
+from rest_framework.test import APIClient
 
 
 class TestDocumentation:
@@ -24,3 +27,40 @@ class TestDocumentation:
         assert reverse_lazy("schema-swagger-ui") == self.url_swagger
         response = self.client.get(self.url_swagger)
         assert response.status_code == status.HTTP_200_OK
+
+
+class TestApiTokenAuth:
+
+    client = APIClient()
+    url = "/api-token-auth/"
+
+    def test_endpoint(self):
+        assert reverse_lazy("api_token_auth") == self.url
+
+    @pytest.mark.django_db
+    def test_invalid(self):
+        return
+        data = {
+            "username": "username",
+            "password": "password",
+        }
+        response = self.client.post(self.url, data, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert (
+            response.data["non_field_errors"][0]
+            == "Unable to log in with provided credentials."
+        )
+
+    @pytest.mark.django_db
+    def test_valid(self):
+        return
+        data = {
+            "username": "username",
+            "password": "password",
+        }
+        user = User.objects.create(username=data["username"])
+        user.set_password(data["password"])
+        user.save()
+        response = self.client.post(self.url, data, format="json")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data.keys() == {"token"}

--- a/src/project_nursing/urls.py
+++ b/src/project_nursing/urls.py
@@ -21,6 +21,7 @@ from nurse.urls import router as nurse_router
 from nurse import views as nurse_views
 from rest_framework import routers, permissions
 from rest_framework.schemas import get_schema_view
+from rest_framework.authtoken.views import obtain_auth_token
 from drf_yasg.views import get_schema_view as drf_yasg_get_schema_view
 from drf_yasg import openapi
 
@@ -46,6 +47,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("account/", include("rest_framework.urls")),
     path("account/register", nurse_views.UserCreate.as_view(), name="register"),
+    path("api-token-auth/", obtain_auth_token, name="api_token_auth"),
     path("", include(router.urls)),
     path(
         "openapi",


### PR DESCRIPTION
By default all endpoints require authentication.
Note we not yet associate user action with identity, but this
will come later.
Refactored tests to leverage token authentication.
Tested the authentication successfully with `curl` via:
```sh
curl \
--data '{"username": "'$USERNAME'", "password": "'$PASSWORD'"}' \
--header "Content-Type: application/json" \
http://localhost:8000/api-token-auth/
```
Response:
```json
{
  "token": "TOKEN"
}
```