### PR TITLE
:goal_net: Configure Sentry error login, fixes #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - :tada: https://mynotif.herokuapp.com/
 - :memo: https://mynotif.herokuapp.com/swagger/
 - :memo: https://mynotif.herokuapp.com/redoc/
+- :goal_net: https://sentry.io/organizations/andre-5t/issues/3096848907/?project=6257099
 
 ## :tada: run
 ```sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ uritemplate==3.0.1
 whitenoise==5.3.0
 wmctrl==0.4
 drf-yasg==1.20.0
+sentry-sdk==1.5.7

--- a/src/project_nursing/settings.py
+++ b/src/project_nursing/settings.py
@@ -11,9 +11,10 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 """
 import os
 import json
-from pathlib import Path
-
+import sentry_sdk
 import django_on_heroku
+from pathlib import Path
+from sentry_sdk.integrations.django import DjangoIntegration
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -150,6 +151,18 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAuthenticatedOrReadOnly",
     ],
 }
+if SENTRY_DSN := os.environ.get("SENTRY_DSN"):
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration()],
+        # Set traces_sample_rate to 1.0 to capture 100%
+        # of transactions for performance monitoring.
+        # We recommend adjusting this value in production.
+        traces_sample_rate=1.0,
+        # If you wish to associate users to errors (assuming you are using
+        # django.contrib.auth) you may enable sending PII data.
+        send_default_pii=True,
+    )
 
 if not DEBUG:
     django_on_heroku.settings(locals())


### PR DESCRIPTION
The `SENTRY_DSN` environment variable was set with:
```sh
heroku config:set SENTRY_DSN=<SENTRY_DSN>
```
Project currently setup under my personal account:
https://sentry.io/organizations/andre-5t/issues/?project=6257099