### PR TITLE
:sparkles: Extend the user serializer with staff and nurse

### DIFF
--- a/src/nurse/serializers.py
+++ b/src/nurse/serializers.py
@@ -35,9 +35,20 @@ class NurseSerializer(serializers.ModelSerializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
+    nurse = serializers.SerializerMethodField()
+
     class Meta:
         model = User
-        fields = ("id", "username", "email", "first_name", "last_name", "password")
+        fields = (
+            "id",
+            "username",
+            "email",
+            "first_name",
+            "last_name",
+            "password",
+            "is_staff",
+            "nurse",
+        )
         read_only_fields = ("id",)
         extra_kwargs = {"password": {"write_only": True}}
 
@@ -47,3 +58,10 @@ class UserSerializer(serializers.ModelSerializer):
         user.set_password(password)
         user.save()
         return user
+
+    def get_nurse(self, obj):
+        # note that we're doing a `get_or_create()` rather than accessing the
+        # `obj.nurse` directly, because it could be some cases where the user
+        # was created without the associated nurse
+        nurse, _ = Nurse.objects.get_or_create(user_id=obj.id)
+        return NurseSerializer(nurse).data

--- a/src/nurse/tests.py
+++ b/src/nurse/tests.py
@@ -106,7 +106,7 @@ class TestPatient:
         )
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == [
+        assert response.json() == [
             {
                 "id": 1,
                 "firstname": "John",
@@ -148,7 +148,7 @@ class TestPatient:
         Patient.objects.create(**self.data)
         response = self.client.get(reverse_lazy("patient-detail", kwargs={"pk": 1}))
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == {
+        assert response.json() == {
             "id": 1,
             "firstname": "John",
             "lastname": "Leen",
@@ -209,7 +209,7 @@ class TestPrescription:
         Prescription.objects.create(**self.data)
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == [
+        assert response.json() == [
             {
                 "id": 1,
                 "carte_vitale": "12345678910",
@@ -231,7 +231,7 @@ class TestPrescription:
             reverse_lazy("prescription-detail", kwargs={"pk": 1})
         )
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == {
+        assert response.json() == {
             "id": 1,
             "carte_vitale": "12345678910",
             "caisse_rattachement": "12345678910",
@@ -290,7 +290,7 @@ class TestNurse:
         user = User.objects.get()
         response = self.client.post(self.url, self.data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
-        assert response.data == {
+        assert response.json() == {
             **self.data,
             **{
                 "id": 1,
@@ -316,7 +316,7 @@ class TestNurse:
         )
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == [
+        assert response.json() == [
             {
                 "id": 1,
                 "user": 1,
@@ -339,7 +339,7 @@ class TestNurse:
         )
         response = self.client.get(reverse_lazy("nurse-detail", kwargs={"pk": 1}))
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == {
+        assert response.json() == {
             "id": 1,
             "user": 1,
             "patients": [],
@@ -380,13 +380,23 @@ class TestUser:
         authenticate(self.client, self.data["username"], self.data["password"])
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == [
+        assert response.json() == [
             {
                 "id": 1,
                 "username": self.data["username"],
                 "first_name": "",
                 "last_name": "",
                 "email": "",
+                "is_staff": False,
+                "nurse": {
+                    "address": "",
+                    "city": "",
+                    "id": 1,
+                    "patients": [],
+                    "phone": "",
+                    "user": 1,
+                    "zip_code": "",
+                },
             }
         ]
 
@@ -394,12 +404,22 @@ class TestUser:
         authenticate(self.client, self.data["username"], self.data["password"])
         response = self.client.get(reverse_lazy("user-detail", kwargs={"pk": None}))
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == {
+        assert response.json() == {
             "id": 1,
             "username": self.data["username"],
             "first_name": "",
             "last_name": "",
             "email": "",
+            "is_staff": False,
+            "nurse": {
+                "id": 1,
+                "address": "",
+                "city": "",
+                "patients": [],
+                "phone": "",
+                "user": 1,
+                "zip_code": "",
+            },
         }
 
     @pytest.mark.parametrize(
@@ -448,9 +468,19 @@ class TestUser:
         )
         assert response.status_code == status.HTTP_200_OK
         data.pop("password")
-        assert response.data == {
+        assert response.json() == {
             **data,
             "id": 1,
+            "is_staff": False,
+            "nurse": {
+                "id": 1,
+                "address": "",
+                "city": "",
+                "patients": [],
+                "phone": "",
+                "user": 1,
+                "zip_code": "",
+            },
         }
 
     def test_partial_update_user(self):
@@ -461,11 +491,21 @@ class TestUser:
             reverse_lazy("user-detail", kwargs={"pk": None}), data, format="json"
         )
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == {
+        assert response.json() == {
             "id": 1,
             "username": self.data["username"],
             "email": "",
+            "is_staff": False,
             **data,
+            "nurse": {
+                "id": 1,
+                "address": "",
+                "city": "",
+                "patients": [],
+                "phone": "",
+                "user": 1,
+                "zip_code": "",
+            },
         }
 
     def test_delete_user(self):
@@ -491,12 +531,22 @@ class TestAccountRegister:
     def test_create(self):
         assert User.objects.filter(**self.username).count() == 0
         response = self.client.post(self.url, self.data, format="json")
-        assert response.data == {
+        assert response.json() == {
             "id": 1,
             "username": "username1",
             "first_name": "",
             "last_name": "",
             "email": "",
+            "is_staff": False,
+            "nurse": {
+                "id": 1,
+                "address": "",
+                "city": "",
+                "patients": [],
+                "phone": "",
+                "user": 1,
+                "zip_code": "",
+            },
         }
         assert response.status_code == status.HTTP_201_CREATED
         users = User.objects.filter(**self.username)
@@ -561,10 +611,20 @@ class TestProfile:
         authenticate(self.client, self.username, self.password)
         response = self.client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == {
+        assert response.json() == {
             "id": 1,
             "username": "username1",
             "first_name": "",
             "last_name": "",
             "email": "",
+            "is_staff": False,
+            "nurse": {
+                "address": "",
+                "city": "",
+                "id": 1,
+                "patients": [],
+                "phone": "",
+                "user": 1,
+                "zip_code": "",
+            },
         }

--- a/src/nurse/views.py
+++ b/src/nurse/views.py
@@ -66,7 +66,7 @@ class UserCreate(generics.CreateAPIView):
         response = super().post(request, *args, **kwargs)
         username = response.data["username"]
         user = User.objects.get(username=username)
-        Nurse.objects.create(
+        Nurse.objects.get_or_create(
             user=user,
         )
         return response


### PR DESCRIPTION
This make it easier for the frontend to pull the entire nurse profile.
Also replaces test `response.data` by `response.json()` the later
produces the same assert result, but is easier to visualise for debugging