### PR TITLE
:pencil2: fix: Upload add trailing slash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@
 #
 asgiref==3.5.2
     # via django
-boto3==1.24.36
+boto3==1.24.51
     # via mynotif (setup.py)
-botocore==1.27.36
+botocore==1.27.51
     # via
     #   boto3
     #   s3transfer
@@ -24,12 +24,13 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-dj-database-url==0.5.0
+dj-database-url==1.0.0
     # via
     #   django-on-heroku
     #   mynotif (setup.py)
-django==3.2.14
+django==3.2.15
     # via
+    #   dj-database-url
     #   django-cors-headers
     #   django-extensions
     #   django-on-heroku
@@ -43,7 +44,7 @@ django-extensions==3.2.0
     # via mynotif (setup.py)
 django-on-heroku==1.1.2
     # via mynotif (setup.py)
-django-storages==1.12.3
+django-storages==1.13.1
     # via mynotif (setup.py)
 djangorestframework==3.13.1
     # via
@@ -83,7 +84,7 @@ python-dateutil==2.8.2
     #   mynotif (setup.py)
 python-dotenv==0.20.0
     # via mynotif (setup.py)
-pytz==2022.1
+pytz==2022.2.1
     # via
     #   django
     #   djangorestframework
@@ -98,7 +99,7 @@ ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
 s3transfer==0.6.0
     # via boto3
-sentry-sdk==1.8.0
+sentry-sdk==1.9.4
     # via mynotif (setup.py)
 six==1.16.0
     # via python-dateutil
@@ -108,7 +109,7 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.10
+urllib3==1.26.11
     # via
     #   botocore
     #   requests

--- a/src/nurse/urls.py
+++ b/src/nurse/urls.py
@@ -19,7 +19,7 @@ router.register("user", UserViewSet)
 urlpatterns = [
     path("profile/", ProfileView.as_view(), name="profile"),
     path(
-        "prescription/upload/<int:pk>",
+        "prescription/upload/<int:pk>/",
         PrescriptionFileView.as_view(),
         name="prescription-upload",
     ),


### PR DESCRIPTION
To be consistent with other endpoints that have trailing slash.
Also bumps the `requirements.txt` via:
```sh
pip-compile > requirements.txt
```