### PR TITLE
:sparkles: Swagger UI (drf-spectacular), fixes #77

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 asgiref==3.5.2
     # via django
+attrs==22.1.0
+    # via jsonschema
 boto3==1.24.51
     # via mynotif (setup.py)
 botocore==1.27.51
@@ -13,17 +15,7 @@ botocore==1.27.51
     #   boto3
     #   s3transfer
 certifi==2022.6.15
-    # via
-    #   requests
-    #   sentry-sdk
-charset-normalizer==2.1.0
-    # via requests
-coreapi==2.3.3
-    # via drf-yasg
-coreschema==0.0.4
-    # via
-    #   coreapi
-    #   drf-yasg
+    # via sentry-sdk
 dj-database-url==1.0.0
     # via
     #   django-on-heroku
@@ -36,7 +28,7 @@ django==3.2.15
     #   django-on-heroku
     #   django-storages
     #   djangorestframework
-    #   drf-yasg
+    #   drf-spectacular
     #   mynotif (setup.py)
 django-cors-headers==3.13.0
     # via mynotif (setup.py)
@@ -48,36 +40,28 @@ django-storages==1.13.1
     # via mynotif (setup.py)
 djangorestframework==3.13.1
     # via
-    #   drf-yasg
+    #   drf-spectacular
     #   mynotif (setup.py)
-drf-yasg==1.21.3
+drf-spectacular==0.23.1
     # via mynotif (setup.py)
 gunicorn==20.1.0
     # via mynotif (setup.py)
-idna==3.3
-    # via requests
 inflection==0.5.1
-    # via drf-yasg
-itypes==1.2.0
-    # via coreapi
-jinja2==3.1.2
-    # via coreschema
+    # via drf-spectacular
 jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-markupsafe==2.1.1
-    # via jinja2
-packaging==21.3
-    # via drf-yasg
+jsonschema==4.9.1
+    # via drf-spectacular
 pillow==9.2.0
     # via mynotif (setup.py)
 psycopg2-binary==2.9.3
     # via
     #   django-on-heroku
     #   mynotif (setup.py)
-pyparsing==3.0.9
-    # via packaging
+pyrsistent==0.18.1
+    # via jsonschema
 python-dateutil==2.8.2
     # via
     #   botocore
@@ -88,15 +72,10 @@ pytz==2022.2.1
     # via
     #   django
     #   djangorestframework
-    #   drf-yasg
 pyyaml==6.0
-    # via mynotif (setup.py)
-requests==2.28.1
-    # via coreapi
-ruamel-yaml==0.17.21
-    # via drf-yasg
-ruamel-yaml-clib==0.2.6
-    # via ruamel-yaml
+    # via
+    #   drf-spectacular
+    #   mynotif (setup.py)
 s3transfer==0.6.0
     # via boto3
 sentry-sdk==1.9.4
@@ -106,13 +85,10 @@ six==1.16.0
 sqlparse==0.4.2
     # via django
 uritemplate==4.1.1
-    # via
-    #   coreapi
-    #   drf-yasg
+    # via drf-spectacular
 urllib3==1.26.11
     # via
     #   botocore
-    #   requests
     #   sentry-sdk
 whitenoise==6.2.0
     # via

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     django-on-heroku
     django-storages
     djangorestframework<4
+    drf-spectacular
     gunicorn
     Pillow
     psycopg2-binary
@@ -31,7 +32,6 @@ install_requires =
     python-dotenv
     PyYAML
     whitenoise
-    drf-yasg
     sentry-sdk
 
 [options.extras_require]

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -45,7 +45,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "drf_yasg",
+    "drf_spectacular",
     "nurse",
     "rest_framework",
     "rest_framework.authtoken",
@@ -156,6 +156,13 @@ REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
     ],
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Mynotif",
+    "DESCRIPTION": "API Mynotif",
+    "VERSION": "1.0.0",
 }
 
 # AWS s3

--- a/src/main/tests.py
+++ b/src/main/tests.py
@@ -9,14 +9,8 @@ from rest_framework.test import APIClient
 class TestDocumentation:
 
     client = Client()
-    url_openapi = "/openapi"
     url_redoc = "/redoc/"
     url_swagger = "/swagger/"
-
-    def test_openapi(self):
-        assert reverse_lazy("openapi-schema") == self.url_openapi
-        response = self.client.get(self.url_openapi)
-        assert response.status_code == status.HTTP_200_OK
 
     def test_redoc(self):
         assert reverse_lazy("schema-redoc") == self.url_redoc

--- a/src/main/urls.py
+++ b/src/main/urls.py
@@ -14,14 +14,16 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, re_path
+from django.urls import path
 from django.urls.conf import include
-from drf_yasg import openapi
-from drf_yasg.views import get_schema_view as drf_yasg_get_schema_view
-from rest_framework import permissions, routers
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularJSONAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
+)
+from rest_framework import routers
 from rest_framework.authtoken.views import obtain_auth_token
-from rest_framework.permissions import AllowAny
-from rest_framework.schemas import get_schema_view
 
 from nurse import views as nurse_views
 from nurse.urls import router as nurse_router
@@ -29,19 +31,6 @@ from nurse.urls import router as nurse_router
 router = routers.DefaultRouter()
 router.registry.extend(nurse_router.registry)
 
-title = "Mynotif"
-description = "API Mynotif"
-version = "1.0.0"
-
-schema_view = drf_yasg_get_schema_view(
-    openapi.Info(
-        title=title,
-        default_version=version,
-        description=description,
-    ),
-    public=True,
-    permission_classes=[permissions.AllowAny],
-)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -51,26 +40,23 @@ urlpatterns = [
     path("api-token-auth/", obtain_auth_token, name="api_token_auth"),
     path("", include(router.urls)),
     path(
-        "openapi",
-        get_schema_view(
-            title=title,
-            description=description,
-            version=version,
-            permission_classes=[AllowAny],
-        ),
-        name="openapi-schema",
-    ),
-    re_path(
-        r"^swagger(?P<format>\.json|\.yaml)$",
-        schema_view.without_ui(cache_timeout=0),
+        "swagger.json",
+        SpectacularJSONAPIView.as_view(),
         name="schema-json",
     ),
-    re_path(
-        r"^swagger/$",
-        schema_view.with_ui("swagger", cache_timeout=0),
+    path(
+        "swagger.yaml",
+        SpectacularAPIView.as_view(),
+        name="schema",
+    ),
+    path(
+        "swagger/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
         name="schema-swagger-ui",
     ),
-    re_path(
-        r"^redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"
+    path(
+        "redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="schema-redoc",
     ),
 ]


### PR DESCRIPTION
Drops `drf-yasg`, for `drf-spectacular` which supports OpenAPI 3.
Note that authentication could have been addressed with the following
setting to deal with `TokenAuthentication`:
```python
SWAGGER_SETTINGS = {
    "SECURITY_DEFINITIONS": {
        "Bearer": {
            "type": "apiKey",
            "in": "header",
            "name": "Authorization",
        }
    }
}
```
![image](https://user-images.githubusercontent.com/24973/184542498-b348ae3c-4d8e-4796-8ebb-32e2e5612d97.png)