### PR TITLE
:break: Prepare terraform backend, refs #62

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ __pycache__
 db.sqlite3
 venv
 *.egg-info
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+**/.terraform.lock.hcl

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 0.12.2"
+
+  backend "s3" {
+    region         = "eu-west-3"
+    bucket         = "mynotif-backend-terraform-state"
+    key            = "terraform.tfstate"
+    dynamodb_table = "mynotif-backend-terraform-state-lock"
+    profile        = ""
+    role_arn       = ""
+    encrypt        = "true"
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~>4.18"
+    }
+  }
+
+  required_version = ">=0.14.9"
+}
+
+provider "aws" {
+  region = var.aws_region
+  # Role to assume for AWS operations
+  assume_role {
+    role_arn = "arn:aws:iam::332944743618:role/mynotif-deployment-automation-role"
+  }
+}
+
+
+# You cannot create a new backend by simply defining this and then
+# immediately proceeding to "terraform apply". The S3 backend must
+# be bootstrapped according to the simple yet essential procedure in
+# https://github.com/cloudposse/terraform-aws-tfstate-backend#usage
+module "terraform_state_backend" {
+  source = "cloudposse/tfstate-backend/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  version    = "0.38.1"
+  namespace  = var.app_name
+  name       = "terraform"
+  attributes = ["state"]
+
+  terraform_backend_config_file_path = "."
+  terraform_backend_config_file_name = "backend.tf"
+  force_destroy                      = false
+}

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,3 @@
+aws_region = "eu-west-3"
+
+app_name = "mynotif-backend"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,9 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Application Name"
+}


### PR DESCRIPTION
`terraform/backend.tf` was generated, refs:
https://github.com/cloudposse/terraform-aws-tfstate-backend

Note that the `mynotif-deployment-automation-role` is managed at higher level in the `mynotif-infra` repository.

Follow up pull request should setup the prescription bucket