### PR TITLE
:zap: Improve Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim as base
 
 ARG PORT=8000
 ENV PORT ${PORT}
@@ -15,5 +15,11 @@ RUN make virtualenv
 COPY src /app/src
 RUN make run/collectstatic
 
-CMD ["make", "run/prod"]
+FROM python:3.11-alpine
+WORKDIR /app
+COPY --from=base /app/venv/ /app/venv/
+COPY src /app/src
+COPY --from=base /app/src/staticfiles/ /app/src/staticfiles/
+
+CMD ["/app/venv/bin/gunicorn", "--chdir", "src", "--bind", "0.0.0.0:8000", "main.wsgi"]
 EXPOSE ${PORT}


### PR DESCRIPTION
Reduce from 378MB to 223MB using multistage builds. This doesn't have an impact on application performance, only on deployment speed