### PR TITLE
:rotating_light: Fix depreciation warnings

### DIFF
--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -152,8 +152,6 @@ TIME_ZONE = os.environ.get("TIME_ZONE", "UTC")
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 
@@ -191,12 +189,23 @@ SPECTACULAR_SETTINGS = {
     "VERSION": "1.0.0",
 }
 
+STATICFILES_STORAGE_BACKEND = "django.contrib.staticfiles.storage.StaticFilesStorage"
+
 # AWS s3
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+DEFAULT_FILE_STORAGE_BACKEND = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_STORAGE_BUCKET_NAME = "mynotif-prescription"
 AWS_S3_REGION_NAME = "eu-west-3"
 AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
+
+STORAGES = {
+    "default": {
+        "BACKEND": DEFAULT_FILE_STORAGE_BACKEND,
+    },
+    "staticfiles": {
+        "BACKEND": STATICFILES_STORAGE_BACKEND,
+    },
+}
 
 # Email configuration
 bool(json.loads(os.environ.get("PRODUCTION", "0")))


### PR DESCRIPTION
The warnings were:
```
venv/lib/python3.11/site-packages/django/conf/__init__.py:267
  /home/andre/workspace/mynotif-backend/venv/lib/python3.11/site-packages/django/conf/__init__.py:267: RemovedInDjango50Warning: The USE_L10N setting is deprecated. Starting with Django 5.0, localized formatting of data will always be enabled. For example Django will display numbers and dates using the format of the current locale.
    warnings.warn(USE_L10N_DEPRECATED_MSG, RemovedInDjango50Warning)

venv/lib/python3.11/site-packages/django/conf/__init__.py:274
  /home/andre/workspace/mynotif-backend/venv/lib/python3.11/site-packages/django/conf/__init__.py:274: RemovedInDjango51Warning: The DEFAULT_FILE_STORAGE setting is deprecated. Use STORAGES instead.
    warnings.warn(DEFAULT_FILE_STORAGE_DEPRECATED_MSG, RemovedInDjango51Warning)
```

Refs: https://docs.djangoproject.com/en/4.2/ref/settings/