### PR TITLE
:fire: Remove at_renew prescription model

### DIFF
--- a/src/nurse/admin.py
+++ b/src/nurse/admin.py
@@ -21,5 +21,4 @@ class PrescriptionAdmin(admin.ModelAdmin):
         "prescribing_doctor",
         "start_date",
         "end_date",
-        "at_renew",
     )

--- a/src/nurse/migrations/0001_initial.py
+++ b/src/nurse/migrations/0001_initial.py
@@ -50,7 +50,6 @@ class Migration(migrations.Migration):
                 ("prescribing_doctor", models.CharField(max_length=300)),
                 ("start_date", models.DateField()),
                 ("end_date", models.DateField()),
-                ("at_renew", models.BooleanField()),
                 ("photo_prescription", models.CharField(max_length=300)),
                 (
                     "patient",

--- a/src/nurse/models.py
+++ b/src/nurse/models.py
@@ -50,7 +50,6 @@ class Prescription(models.Model):
     prescribing_doctor = models.CharField(max_length=300, blank=False)
     start_date = models.DateField(auto_now=False, auto_now_add=False)
     end_date = models.DateField(auto_now=False, auto_now_add=False)
-    at_renew = models.BooleanField(blank=False)
     photo_prescription = models.ImageField(upload_to="prescriptions")
     patient = models.ForeignKey(Patient, on_delete=models.SET_NULL, null=True)
 

--- a/src/nurse/tests.py
+++ b/src/nurse/tests.py
@@ -67,7 +67,6 @@ prescription_data = {
     "prescribing_doctor": "Dr Leen",
     "start_date": "2022-07-15",
     "end_date": "2022-07-31",
-    "at_renew": 1,
 }
 
 patient_data = {
@@ -187,7 +186,6 @@ class TestPatient:
                     "prescribing_doctor": "Dr Leen",
                     "start_date": "2022-08-10",
                     "end_date": "2022-08-20",
-                    "at_renew": 1,
                     "photo_prescription": None,
                     "is_valid": True,
                 },
@@ -199,7 +197,6 @@ class TestPatient:
                     "prescribing_doctor": "Dr Leen",
                     "start_date": "2022-08-01",
                     "end_date": "2022-08-10",
-                    "at_renew": 1,
                     "photo_prescription": None,
                     "is_valid": False,
                 },
@@ -272,7 +269,6 @@ class TestPrescription:
         assert prescription.prescribing_doctor == "Dr Leen"
         assert prescription.start_date == date(2022, 7, 15)
         assert prescription.end_date == date(2022, 7, 31)
-        assert prescription.at_renew == 1
         assert prescription.photo_prescription.name == ""
 
     @freeze_time("2022-08-11")
@@ -296,7 +292,6 @@ class TestPrescription:
                 "prescribing_doctor": "Dr Leen",
                 "start_date": "2022-07-15",
                 "end_date": "2022-07-31",
-                "at_renew": 1,
                 "photo_prescription": None,
                 "patient": patient.id,
                 "is_valid": False,
@@ -329,7 +324,6 @@ class TestPrescription:
             "prescribing_doctor": "Dr Leen",
             "start_date": "2022-07-15",
             "end_date": "2022-07-31",
-            "at_renew": 1,
             "photo_prescription": None,
             "patient": patient.id,
             "is_valid": True,


### PR DESCRIPTION
This commit removes the 'at_renew some model prescription'
    as it is no longer used in our application