### PR TITLE
:wrench: Remove prescription limit in PatientSerializer

### DIFF
--- a/src/nurse/serializers.py
+++ b/src/nurse/serializers.py
@@ -14,7 +14,7 @@ class PatientSerializer(serializers.ModelSerializer):
     def get_prescriptions(self, obj):
         prescriptions = Prescription.objects.filter(patient_id=obj.id).order_by(
             "-end_date"
-        )[:2]
+        )
         return PrescriptionSerializer(prescriptions, many=True).data
 
 


### PR DESCRIPTION
This commit removes the prescription limit in the PatientSerializer's get_prescriptions method. Previously, the method was fetching only the two most recent prescriptions related to the patient. Now, it retrieves all prescriptions associated with the patient, allowing for a comprehensive list of prescriptions.

Changes made:
- Removed the [:2] from the Prescription.objects.filter query in get_prescriptions method.

This modification ensures that all prescriptions related to the patient will be included in the serialized output,
providing a complete record of the patient's prescriptions in the API response.