### PR TITLE
:sparkles: Admin notification view

### DIFF
--- a/src/nurse/urls.py
+++ b/src/nurse/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from rest_framework import routers
 
 from nurse.views import (
+    AdminNotificationView,
     NurseViewSet,
     PatientViewSet,
     PrescriptionFileView,
@@ -23,6 +24,7 @@ urlpatterns = [
         PrescriptionFileView.as_view(),
         name="prescription-upload",
     ),
+    path("notify/", AdminNotificationView.as_view(), name="notify"),
 ]
 
 urlpatterns += router.urls

--- a/src/nurse/views.py
+++ b/src/nurse/views.py
@@ -1,10 +1,11 @@
 from django.contrib.auth.models import User
-from rest_framework import generics, mixins, viewsets
+from rest_framework import generics, mixins, status, viewsets
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from nurse.management.commands._notifications import notify
 from nurse.models import Nurse, Patient, Prescription
 from nurse.serializers import (
     NurseSerializer,
@@ -96,3 +97,13 @@ class UserCreate(generics.CreateAPIView):
         user = User.objects.get(username=username)
         Nurse.objects.get_or_create(user=user)
         return response
+
+
+class AdminNotificationView(APIView):
+    """The view dealing with sending push notifications."""
+
+    permission_classes = [IsAuthenticated, IsAdminUser]
+
+    def post(self, request):
+        notify()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
Introduce a new endpoint `/notify/` to send notifications.
The endpoint is under authentication and only staff users are allowed