### PR TITLE
:sparkles: AppRunner custom domain

### DIFF
--- a/terraform/apprunner.tf
+++ b/terraform/apprunner.tf
@@ -55,3 +55,9 @@ resource "aws_apprunner_service" "backend" {
     }
   }
 }
+
+resource "aws_apprunner_custom_domain_association" "backend" {
+  provider    = aws.app_runner
+  domain_name = local.backend_subdomain
+  service_arn = aws_apprunner_service.backend.arn
+}

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -1,0 +1,20 @@
+data "aws_route53_zone" "this" {
+  name = var.domain_name
+}
+
+resource "aws_route53_record" "cert_validation_records" {
+  count   = 3
+  zone_id = data.aws_route53_zone.this.id
+  name    = tolist(aws_apprunner_custom_domain_association.backend.certificate_validation_records)[count.index].name
+  type    = tolist(aws_apprunner_custom_domain_association.backend.certificate_validation_records)[count.index].type
+  records = [tolist(aws_apprunner_custom_domain_association.backend.certificate_validation_records)[count.index].value]
+  ttl     = var.record_ttl
+}
+
+resource "aws_route53_record" "backend_domain" {
+  zone_id = data.aws_route53_zone.this.id
+  name    = aws_apprunner_custom_domain_association.backend.domain_name
+  type    = "CNAME"
+  records = [aws_apprunner_service.backend.service_url]
+  ttl     = var.record_ttl
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,6 +29,19 @@ variable "environment" {
   default     = "production"
 }
 
+## Domain setup
+variable "domain_name" {
+  type        = string
+  description = "Application domain"
+  default     = "ordopro.fr"
+}
+
+variable "record_ttl" {
+  type        = number
+  description = "The TTL of the record"
+  default     = 300
+}
+
 ## App Runner environment variables definition
 variable "env_allowed_hosts" {
   type        = list(string)
@@ -37,6 +50,7 @@ variable "env_allowed_hosts" {
     "127.0.0.1",
     "localhost",
     ".eu-central-1.awsapprunner.com",
+    "api.ordopro.fr",
   ]
 }
 
@@ -47,6 +61,7 @@ variable "env_csrf_trusted_origins" {
     "http://127.0.0.1",
     "http://localhost",
     "https://*.eu-central-1.awsapprunner.com",
+    "https://api.ordopro.fr",
   ]
 }
 
@@ -131,5 +146,6 @@ variable "lambda_python_runtime" {
 }
 
 locals {
-  image_name = "${var.app_name}-${var.environment}"
+  image_name        = "${var.app_name}-${var.environment}"
+  backend_subdomain = "api.${var.domain_name}"
 }


### PR DESCRIPTION
Note custom domain setup requires record validation. This got borrowed from:
https://github.com/hashicorp/terraform-provider-aws/issues/23460#issuecomment-1356351305