### PR TITLE
:white_check_mark: Update broken unit tests

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -14,10 +14,10 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: docker/setup-buildx-action@v2
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -26,7 +26,7 @@ jobs:
           role-duration-seconds: 1200
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
       # so we can leverage caching during the build phase
       - run: make docker/pull || true
       - run: make docker/build
@@ -43,8 +43,8 @@ jobs:
       DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
       DATABASE_PORT: 5432
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - run: make run/migrations/check
@@ -58,8 +58,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: hashicorp/setup-terraform@v2
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
       - run: make devops/terraform/init

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
       - run: make virtualenv/test

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/3.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
+
 import json
 import os
 from pathlib import Path

--- a/src/main/urls.py
+++ b/src/main/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path
 from django.urls.conf import include

--- a/src/nurse/tests/test_views.py
+++ b/src/nurse/tests/test_views.py
@@ -10,7 +10,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 from django.urls.base import reverse_lazy
 from freezegun import freeze_time
-from moto import mock_s3
+from moto import mock_aws
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -101,7 +101,7 @@ def get_test_image():
 
 @pytest.fixture
 def s3_mock():
-    with mock_s3():
+    with mock_aws():
         s3 = boto3.client("s3", region_name="us-east-1")
         s3.create_bucket(Bucket="mynotif-prescription")
         yield

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -7,7 +7,6 @@ terraform {
     key            = "terraform.tfstate"
     dynamodb_table = "mynotif-backend-terraform-state-lock"
     profile        = ""
-    role_arn       = ""
     encrypt        = "true"
   }
 }


### PR DESCRIPTION
API changed between moto 4 and moto 5. The error was:
```
ImportError while importing test module 'mynotif-backend/src/nurse/tests/test_views.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
src/nurse/tests/test_views.py:13: in <module>
    from moto import mock_s3
E   ImportError: cannot import name 'mock_s3' from 'moto' (mynotif-backend/venv/lib/python3.11/site-packages/moto/__init__.py)
```
Also bumped GitHub Actions versions.

Also update formatting after black got updated and the Terraform code, the error was:
```
│ Error: Cannot assume IAM Role
│
│ IAM Role ARN not set
│   on backend.tf line 4, in terraform:
│    4:   backend "s3" {
│ The following parameters have been deprecated. Replace them as follows:
│   * role_arn -> assume_role.role_arn
```