### PR TITLE
:lock: Migrate secret key to SSM, fix #63

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+SECRET_KEY=
 CORS_ALLOWED_ORIGINS=["http://localhost:3000"]
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,13 @@ DEPLOYMENT_AUTOMATION_ROLE=arn:aws:iam::$(AWS_ACCOUNT_ID):role/mynotif-deploymen
 SESSION_NAME=deployment-session
 AWS_PROFILE?=default
 REGION=eu-west-3
+APPRUNNER_REGION=eu-central-1
 REGISTRY=$(AWS_ACCOUNT_ID).dkr.ecr.$(REGION).amazonaws.com
 APP_NAME=mynotif-backend
 IMAGE_NAME=$(APP_NAME)-production
 DOCKER_IMAGE=$(REGISTRY)/$(IMAGE_NAME)
 SOURCES=src/
-APPRUNNER_ARN=arn:aws:apprunner:eu-central-1:$(AWS_ACCOUNT_ID):service/$(APP_NAME)-runner-production/34b4084ddade4d85be8e625e6b55ea5a
+APPRUNNER_ARN=arn:aws:apprunner:$(APPRUNNER_REGION):$(AWS_ACCOUNT_ID):service/$(APP_NAME)-runner-production/34b4084ddade4d85be8e625e6b55ea5a
 
 
 all: virtualenv
@@ -143,4 +144,4 @@ devops/terraform/destroy:
 	terraform -chdir=terraform destroy -auto-approve
 
 devops/aws/redeploy/apprunner:
-	aws apprunner update-service --service-arn $(APPRUNNER_ARN)
+	aws apprunner start-deployment --service-arn $(APPRUNNER_ARN) --region $(APPRUNNER_REGION)

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -15,6 +15,7 @@ import os
 from pathlib import Path
 
 import sentry_sdk
+from django.core.management.utils import get_random_secret_key
 from dotenv import load_dotenv
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -28,7 +29,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-gmzzy_phk&y296hn9k&@st$@^4)_wz1ssaz0y0l@ck8xa=mda*"
+SECRET_KEY = os.environ.get("SECRET_KEY", get_random_secret_key())
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = not bool(json.loads(os.environ.get("PRODUCTION", "0")))

--- a/terraform/apprunner.tf
+++ b/terraform/apprunner.tf
@@ -22,6 +22,7 @@ resource "aws_apprunner_service" "backend" {
       image_configuration {
         port = "8000"
         runtime_environment_variables = {
+          SECRET_KEY                  = data.aws_ssm_parameter.secret_key.value
           TIME_ZONE                   = var.env_time_zone
           ALLOWED_HOSTS               = jsonencode(var.env_allowed_hosts)
           CSRF_TRUSTED_ORIGINS        = jsonencode(var.env_csrf_trusted_origins)

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,12 +1,13 @@
 terraform {
-  required_version = ">= 0.12.2"
+  required_version = ">= 1.0.0"
 
   backend "s3" {
-    region         = "eu-west-3"
-    bucket         = "mynotif-backend-terraform-state"
-    key            = "terraform.tfstate"
+    region  = "eu-west-3"
+    bucket  = "mynotif-backend-terraform-state"
+    key     = "terraform.tfstate"
+    profile = ""
+    encrypt = "true"
+
     dynamodb_table = "mynotif-backend-terraform-state-lock"
-    profile        = ""
-    encrypt        = "true"
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -33,7 +33,7 @@ provider "aws" {
 module "terraform_state_backend" {
   source = "cloudposse/tfstate-backend/aws"
   # Cloud Posse recommends pinning every module to a specific version
-  version    = "0.38.1"
+  version    = "1.4.1"
   namespace  = var.app_name
   name       = "terraform"
   attributes = ["state"]

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -1,3 +1,7 @@
+data "aws_ssm_parameter" "secret_key" {
+  name = "${var.app_name}-secret-key-${var.environment}"
+}
+
 data "aws_ssm_parameter" "sentry_dsn" {
   name = "${var.app_name}-sentry-dsn-${var.environment}"
 }


### PR DESCRIPTION
Also update Terraform backend provider version to fix deprecated role_arn field, refs:
https://github.com/cloudposse/terraform-aws-tfstate-backend/issues/146

Also update the `devops/aws/redeploy/apprunner` make target to specify the region and change redeployment command, the errors were:
```
The service arn provided in the request does not belong to the current region
No configurations provided in the UpdateService request.
```