### PR TITLE
:bug: Fix notification UnboundLocalError

### DIFF
--- a/src/nurse/management/commands/_notifications.py
+++ b/src/nurse/management/commands/_notifications.py
@@ -34,12 +34,13 @@ def notify():
         **filter_args
     ).values_list("subscription_id", flat=True)
     subscription_ids |= set(subscription_id_list)
-    if subscription_ids:
-        notification_body = {
-            "contents": contents_dict,
-            "include_subscription_ids": subscription_ids,
-            "name": "PRESCRIPTION EXPIRE SOON",
-        }
+    if not subscription_ids:
+        return
+    notification_body = {
+        "contents": contents_dict,
+        "include_subscription_ids": subscription_ids,
+        "name": "PRESCRIPTION EXPIRE SOON",
+    }
     get_client().send_notification(notification_body)
 
 

--- a/src/tests/nurse/management/commands/test_notifications.py
+++ b/src/tests/nurse/management/commands/test_notifications.py
@@ -97,6 +97,16 @@ class TestNotifications:
             mock.call(expected_notification_body)
         ]
 
+    @pytest.mark.django_db
+    def test_notify_no_subscription(self):
+        with mock.patch(
+            f"{client_path}.send_notification"
+        ) as mock_send_notification, override_settings(
+            ONESIGNAL_APP_ID="ONESIGNAL_APP_ID", ONESIGNAL_API_KEY="ONESIGNAL_API_KEY"
+        ):
+            _notifications.notify()
+        assert mock_send_notification.call_count == 0
+
     def test_get_client_with_valid_settings(self):
         with override_settings(
             ONESIGNAL_APP_ID=ONESIGNAL_APP_ID,


### PR DESCRIPTION
The error was:
```
cannot access local variable 'notification_body' where it is not associated with a value
```