### PR TITLE
:bug: remove no-reply notice and update sender email fix #165

### DIFF
--- a/src/nurse/templates/emails/email_template.html
+++ b/src/nurse/templates/emails/email_template.html
@@ -6,11 +6,6 @@
     <title>Renouvellement d'ordonnance</title>
 </head>
 <body>
-    <header>
-        <p>
-            Cet e-mail a été envoyé à partir d'une adresse e-mail dédiée au renouvellement et n'accepte pas de réponses.
-        </p>
-    </header>
     <main>
         <h1>Renouvellement d'ordonnance</h1>
         <div>

--- a/src/nurse/views.py
+++ b/src/nurse/views.py
@@ -1,5 +1,3 @@
-import os
-
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
 from django.shortcuts import get_object_or_404
@@ -51,9 +49,14 @@ class SendEmailToDoctorView(APIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        if not user.first_name or not user.last_name:
+        if not user.first_name or not user.last_name or not user.email:
             return Response(
-                {"error": "Please update your profile with your first and last name"},
+                {
+                    "error": (
+                        "Please update your profile with your first and last name "
+                        "and email"
+                    )
+                },
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -72,7 +75,7 @@ class SendEmailToDoctorView(APIView):
             send_mail(
                 subject,
                 "",
-                os.environ.get("EMAIL_HOST_USER"),
+                user.email,
                 [email_doctor],
                 fail_silently=False,
                 html_message=html_message,

--- a/src/tests/nurse/test_views.py
+++ b/src/tests/nurse/test_views.py
@@ -22,6 +22,7 @@ USERNAME = "username1"
 PASSWORD = "password1"
 FIRSTNAME = "John"
 LASTNAME = "Doe"
+EMAIL = "sendemail@ordopro.fr"
 
 
 def patch_notify():
@@ -32,7 +33,7 @@ def patch_notify():
 def user(db):
     """Creates and yields a new user."""
     user = User.objects.create(
-        username=USERNAME, first_name=FIRSTNAME, last_name=LASTNAME
+        username=USERNAME, first_name=FIRSTNAME, last_name=LASTNAME, email=EMAIL
     )
     user.set_password(PASSWORD)
     user.save()
@@ -44,7 +45,7 @@ def user(db):
 def user2(db):
     """Creates and yields a new user."""
     user = User.objects.create(
-        username="username2", first_name=FIRSTNAME, last_name=LASTNAME
+        username="username2", first_name=FIRSTNAME, last_name=LASTNAME, email=EMAIL
     )
     user.set_password(PASSWORD)
     user.save()
@@ -168,6 +169,7 @@ class TestSendEmailToDoctorView:
         assert response.data == {"message": "Email sent"}
         assert len(mail.outbox) == 1
         assert mail.outbox[0].to == [prescription.email_doctor]
+        assert mail.outbox[0].from_email == user.email
 
         # Check the rendered email message
         email = mail.outbox[0]
@@ -195,11 +197,14 @@ class TestSendEmailToDoctorView:
     def test_user_without_name(self, client, prescription, user):
         user.first_name = ""
         user.last_name = ""
+        user.email = ""
         user.save()
         response = client.post(self.url, self.valid_payload)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
-            "error": "Please update your profile with your first and last name"
+            "error": (
+                "Please update your profile with your first and last name and email"
+            )
         }
 
     def test_send_email_to_doctor_500(self, client, prescription):
@@ -709,7 +714,7 @@ class TestUser:
                 "username": user.username,
                 "first_name": "John",
                 "last_name": "Doe",
-                "email": "",
+                "email": EMAIL,
                 "is_staff": False,
                 "nurse": {
                     "address": "",
@@ -740,7 +745,7 @@ class TestUser:
             "username": user.username,
             "first_name": "John",
             "last_name": "Doe",
-            "email": "",
+            "email": EMAIL,
             "is_staff": False,
             "nurse": {
                 "id": 1,
@@ -825,7 +830,7 @@ class TestUser:
         assert response.json() == {
             "id": 1,
             "username": user.username,
-            "email": "",
+            "email": EMAIL,
             "is_staff": False,
             **data,
             "nurse": {
@@ -939,7 +944,7 @@ class TestProfile:
             "username": USERNAME,
             "first_name": "John",
             "last_name": "Doe",
-            "email": "",
+            "email": EMAIL,
             "is_staff": False,
             "nurse": {
                 "address": "",


### PR DESCRIPTION
1. Modify the `SendEmailToDoctorView` to use the user's email address as the `from_email` parameter in the `send_mail` function, instead of the `EMAIL_HOST_USER` environment variable. This ensures that the email is sent from the user's email address, allowing the recipient to reply directly to the user.

2. Remove the sentence "Cet e-mail a été envoyé à partir d'une adresse e-mail dédiée au renouvellement et n'accepte pas de réponses." from the email template.
This message is no longer necessary
since the email is now sent from the user's email address.

3. Update the test `test_send_email_to_doctor` to verify that the email is sent from the user's email address and
that the "no-reply" message is no longer present in the email body.

To see for more information [ticket](https://github.com/mynotif/mynotif-backend/issues/165)