### PR TITLE
:arrow_up: Bump to Django 5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,13 +32,13 @@ charset-normalizer==3.4.0
     # via requests
 cryptography==43.0.3
     # via social-auth-core
-cython==0.29.37
+cython==3.0.11
     # via mynotif (setup.py)
 defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-django==4.2.16
+django==5.0.9
     # via
     #   django-cors-headers
     #   django-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,8 +17,8 @@ classifiers =
 [options]
 install_requires =
     boto3
-    Cython<3
-    Django<5
+    Cython
+    Django<5.1
     django-cors-headers
     django-extensions
     django-storages


### PR DESCRIPTION
Also bump to Cython 3, the build error was fixed in later version, refs https://github.com/mynotif/mynotif-backend/pull/115

Note that Django 5.1 is breaking djoser 2.2.3, the error is:
```
_pickle.PicklingError: Cannot pickle ResolverMatch
```
Refs https://github.com/sunscrapers/djoser/issues/842