### PR TITLE
:arrow_up: Bump AWS Lambda Python runtime to 3.12

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -59,6 +59,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          # 3.13 isn't yet available in lambdas
+          python-version: 3.12
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -1,6 +1,6 @@
 module "lambda_function" {
   source         = "terraform-aws-modules/lambda/aws"
-  version        = "6.0.0"
+  version        = "7.14.0"
   function_name  = "${var.app_name}-onesignal-notifications"
   handler        = "notify.handler"
   runtime        = var.lambda_python_runtime

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~>4.18"
+      version = ">= 5.70.0"
     }
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -145,7 +145,7 @@ variable "env_templated_site_name" {
 variable "lambda_python_runtime" {
   description = "AWS Lambda Python runtime version"
   type        = string
-  default     = "python3.10"
+  default     = "python3.12"
 }
 
 locals {


### PR DESCRIPTION
This is a follow up for #172, but 3.13 isn't yet available in lambdas

Split this PR up as it's doing backend optimizations as well.