### PR TITLE
:zap: Dynamic patient fields selection

### DIFF
--- a/src/nurse/serializers.py
+++ b/src/nurse/serializers.py
@@ -5,7 +5,29 @@ from rest_framework import serializers
 from nurse.models import Nurse, Patient, Prescription, UserOneSignalProfile
 
 
-class PatientSerializer(serializers.ModelSerializer):
+class DynamicFieldsModelSerializer(serializers.ModelSerializer):
+    """
+    A ModelSerializer that takes an additional `fields` argument that controls which
+    fields should be displayed.
+    https://github.com/encode/django-rest-framework/blob/3.15.2/docs/api-guide/serializers.md#dynamically-modifying-fields
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Don't pass the 'fields' arg up to the superclass
+        fields = kwargs.pop("fields", None)
+
+        # Instantiate the superclass normally
+        super().__init__(*args, **kwargs)
+
+        if fields is not None:
+            # Drop any fields that are not specified in the `fields` argument.
+            allowed = set(fields)
+            existing = set(self.fields)
+            for field_name in existing - allowed:
+                self.fields.pop(field_name)
+
+
+class PatientSerializer(DynamicFieldsModelSerializer):
     prescriptions = serializers.SerializerMethodField()
     expire_soon_prescriptions = serializers.SerializerMethodField()
 

--- a/src/tests/nurse/test_views.py
+++ b/src/tests/nurse/test_views.py
@@ -377,6 +377,23 @@ class TestPatient:
 
         assert response.json() == [expected_data]
 
+    def test_patient_list_with_fields(self, user, client):
+        patient = Patient.objects.create(**self.data)
+        nurse, _ = Nurse.objects.get_or_create(user=user)
+        patient.nurse_set.add(nurse)
+        fields = "id,firstname,lastname,city,zip_code,street"
+        response = client.get(self.url, {"fields": fields})
+        assert response.status_code == status.HTTP_200_OK
+        expected_data = {
+            "id": 1,
+            "firstname": "John",
+            "lastname": "Leen",
+            "street": "3 place du cerdan",
+            "zip_code": "95400",
+            "city": "courdimanche",
+        }
+        assert response.json() == [expected_data]
+
     def test_patient_list_401(self):
         """The endpoint should be under authentication."""
         response = APIClient().get(self.url)


### PR DESCRIPTION
Let the frontend choose the field subset dynamically on /patient/ using the `field` query parameter. Returns all fields by default.

Example:
     GET /patient/?fields=id,firstname,lastname

This should improve the performance on the GET /patient/ endpoint.