### PR TITLE
Add patient first and last names to prescription serializer

### DIFF
--- a/src/nurse/serializers.py
+++ b/src/nurse/serializers.py
@@ -59,7 +59,7 @@ class PrescriptionEmailSerializer(serializers.Serializer):
     )
 
 
-class PrescriptionSerializer(serializers.ModelSerializer):
+class PrescriptionSerializer(DynamicFieldsModelSerializer):
     is_valid = serializers.SerializerMethodField()
     expiring_soon = serializers.SerializerMethodField()
 
@@ -73,6 +73,15 @@ class PrescriptionSerializer(serializers.ModelSerializer):
 
     def get_expiring_soon(self, obj):
         return obj.expiring_soon()
+
+
+class ExpandedPrescriptionSerializer(PrescriptionSerializer):
+    """Serializer for prescription details, including patient's first and last names."""
+
+    patient_firstname = serializers.CharField(
+        source="patient.firstname", read_only=True
+    )
+    patient_lastname = serializers.CharField(source="patient.lastname", read_only=True)
 
 
 class PrescriptionFileSerializer(serializers.ModelSerializer):

--- a/src/nurse/views.py
+++ b/src/nurse/views.py
@@ -11,11 +11,11 @@ from rest_framework.views import APIView
 from nurse.management.commands._notifications import notify
 from nurse.models import Nurse, Patient, Prescription, UserOneSignalProfile
 from nurse.serializers import (
+    ExpandedPrescriptionSerializer,
     NurseSerializer,
     PatientSerializer,
     PrescriptionEmailSerializer,
     PrescriptionFileSerializer,
-    PrescriptionSerializer,
     UserOneSignalProfileSerializer,
     UserSerializer,
 )
@@ -139,7 +139,7 @@ class PatientViewSet(DynamicFieldsMixin, viewsets.ModelViewSet):
 
 class PrescriptionViewSet(viewsets.ModelViewSet):
     queryset = Prescription.objects.all()
-    serializer_class = PrescriptionSerializer
+    serializer_class = ExpandedPrescriptionSerializer
 
     def get_queryset(self):
         """Only the prescriptions associated to the logged in nurse."""

--- a/src/tests/nurse/test_views.py
+++ b/src/tests/nurse/test_views.py
@@ -527,6 +527,8 @@ class TestPrescription:
                 "end_date": "2022-07-31",
                 "photo_prescription": None,
                 "patient": patient.id,
+                "patient_firstname": "John",
+                "patient_lastname": "Leen",
                 "is_valid": False,
                 "expiring_soon": False,
             }
@@ -555,6 +557,8 @@ class TestPrescription:
             "end_date": "2022-07-31",
             "photo_prescription": None,
             "patient": patient.id,
+            "patient_firstname": "John",
+            "patient_lastname": "Leen",
             "is_valid": True,
             "expiring_soon": False,
         }


### PR DESCRIPTION
Added patient_firstname and patient_lastname fields to the PrescriptionSerializer to include patient name details in prescription responses.

Updated test cases to validate these new fields.
These changes address multiple requests
for expanded patient information in prescription data.