### PR TITLE
:sparkles: Email authentication, fixes #168

### DIFF
--- a/src/main/serializers.py
+++ b/src/main/serializers.py
@@ -1,0 +1,18 @@
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+from rest_framework.authtoken.serializers import AuthTokenSerializer
+
+
+class CustomAuthTokenSerializer(AuthTokenSerializer):
+    """
+    Override rest_framework.authtoken.serializers.AuthTokenSerializer to authenticate
+    via email and password.
+    """
+
+    username = None
+    email = serializers.EmailField(label=_("Email"), write_only=True)
+
+    def validate(self, attrs):
+        """Map email to username for compatibility with AuthTokenSerializer logic."""
+        attrs["username"] = attrs.get("email")
+        return super().validate(attrs)

--- a/src/main/urls.py
+++ b/src/main/urls.py
@@ -34,6 +34,14 @@ from . import views as main_views
 router = routers.DefaultRouter()
 router.registry.extend(nurse_router.registry)
 
+v2_urlpatterns = [
+    path("account/register", nurse_views.UserCreateV2.as_view(), name="register"),
+    path(
+        "api-token-auth/",
+        main_views.CustomObtainAuthToken.as_view(),
+        name="api_token_auth",
+    ),
+]
 
 urlpatterns = [
     path("version/", main_views.version, name="version"),
@@ -64,4 +72,5 @@ urlpatterns = [
         SpectacularRedocView.as_view(url_name="schema"),
         name="schema-redoc",
     ),
+    path("api/v2/", include((v2_urlpatterns, "v2"), namespace="v2")),
 ]

--- a/src/main/views.py
+++ b/src/main/views.py
@@ -1,8 +1,20 @@
 import os
 
 from django.http import JsonResponse
+from rest_framework.authtoken.views import ObtainAuthToken
+
+from main.serializers import CustomAuthTokenSerializer
 
 
 def version(_request):
     version = os.environ.get("VERSION") or "0.0.0"
     return JsonResponse({"version": version})
+
+
+class CustomObtainAuthToken(ObtainAuthToken):
+    """
+    Override rest_framework.authtoken.views.ObtainAuthToken to authenticate via email
+    and password.
+    """
+
+    serializer_class = CustomAuthTokenSerializer

--- a/src/nurse/serializers.py
+++ b/src/nurse/serializers.py
@@ -129,6 +129,31 @@ class UserSerializer(serializers.ModelSerializer):
         return NurseSerializer(nurse).data
 
 
+class UserSerializerV2(UserSerializer):
+    """
+    V2 serializer inherits from V1 but excludes `username` field.
+    Automatically sets `username` to the provided `email`.
+    """
+
+    class Meta(UserSerializer.Meta):
+        """Exclude `username` from fields."""
+
+        fields = (
+            "id",
+            "email",
+            "first_name",
+            "last_name",
+            "password",
+            "is_staff",
+            "nurse",
+        )
+
+    def create(self, validated_data):
+        """Automatically set `username` to `email`."""
+        validated_data["username"] = validated_data["email"]
+        return super().create(validated_data)
+
+
 class UserOneSignalProfileSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserOneSignalProfile


### PR DESCRIPTION
Introduce `/api/v2/account/register` for account creation using email and `/api/v2/api-token-auth/` for authentication using email. Note that we tried to take a different approach for addressing email authentication. Instead of using a custom `AUTH_USER_MODEL` we still use the same default model, but feed the `username` with the `email` during register and login phases.

Note that while we didn't write any User.email -> User.username data migration script, it's possible to deal with it later if we want to. This assumes existing user can still login using their username rather than email.