### PR TITLE
:lock: Prevent from listing all users

### DIFF
--- a/src/nurse/views.py
+++ b/src/nurse/views.py
@@ -205,6 +205,10 @@ class UserViewSet(
     queryset = User.objects.all()
     serializer_class = UserSerializer
 
+    def get_queryset(self):
+        """Limit the queryset to only include the current user."""
+        return User.objects.filter(id=self.request.user.id)
+
     def get_object(self):
         """Fecthing a specific object other than `request.user` isn't allowed."""
         if self.kwargs.get("pk").isdigit():

--- a/src/tests/nurse/test_views.py
+++ b/src/tests/nurse/test_views.py
@@ -742,8 +742,7 @@ class TestUser:
         User.objects.create(username="another-user")
         response = client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
-        # TODO: this is a bug, we shouldn't be able to list other users
-        assert response.json() != expected_response
+        assert response.data == expected_response
 
     def test_detail_user(self, user, client):
         response = client.get(reverse_lazy("v1:user-detail", kwargs={"pk": None}))


### PR DESCRIPTION
The `/api/v1/user/` endpoint to return only the logged in user.