### PR TITLE
:bricks: Frontend app subdomain

### DIFF
--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -21,19 +21,39 @@ resource "aws_route53_record" "backend_domain" {
 }
 
 ## Frontend domain setup
-resource "aws_route53_record" "vercel_root" {
+# The landing/root marketing website, served via GitHub Pages, see:
+# https://github.com/mynotif/website
+resource "aws_route53_record" "frontend_root" {
   zone_id = data.aws_route53_zone.this.zone_id
-  name    = local.frontend_domain
+  name    = var.domain_name
   type    = "A"
   ttl     = var.record_ttl
-  records = var.vercel_root_records
+  records = var.github_pages_a_records
 }
 
-resource "aws_route53_record" "vercel_www" {
+resource "aws_route53_record" "frontend_root_ipv6" {
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = var.domain_name
+  type    = "AAAA"
+  ttl     = var.record_ttl
+  records = var.github_pages_aaaa_records
+}
+
+resource "aws_route53_record" "frontend_www" {
   zone_id = data.aws_route53_zone.this.zone_id
   name    = "www"
   type    = "CNAME"
-  records = var.vercel_www_records
+  records = var.github_pages_cname_records
+  ttl     = var.record_ttl
+}
+
+# The application web page, served via Vercel, see:
+# https://github.com/mynotif/mynotif-frontend
+resource "aws_route53_record" "vercel_frontend_app" {
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = local.frontend_domain_prefix
+  type    = "CNAME"
+  records = var.vercel_cname_records
   ttl     = var.record_ttl
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,15 +29,37 @@ variable "domain_name" {
   default     = "ordopro.fr"
 }
 
-variable "vercel_root_records" {
+variable "github_pages_cname_records" {
   type        = list(string)
-  description = "Vercel frontend domain mapping."
-  default     = ["76.76.21.21"]
+  description = "GitHub Pages frontend landing domain mapping."
+  default     = ["mynotif.github.io"]
 }
 
-variable "vercel_www_records" {
+variable "github_pages_a_records" {
+  description = "GitHub Pages A records for IPv4."
   type        = list(string)
-  description = "Vercel frontend domain mapping."
+  default = [
+    "185.199.108.153",
+    "185.199.109.153",
+    "185.199.110.153",
+    "185.199.111.153"
+  ]
+}
+
+variable "github_pages_aaaa_records" {
+  description = "GitHub Pages AAAA records for IPv6."
+  type        = list(string)
+  default = [
+    "2606:50c0:8000::153",
+    "2606:50c0:8001::153",
+    "2606:50c0:8002::153",
+    "2606:50c0:8003::153"
+  ]
+}
+
+variable "vercel_cname_records" {
+  type        = list(string)
+  description = "Vercel frontend app domain mapping."
   default     = ["cname.vercel-dns.com."]
 }
 
@@ -112,6 +134,7 @@ variable "env_cors_allowed_origins" {
     "https://mynotif.netlify.app",
     "https://ordopro.fr",
     "https://www.ordopro.fr",
+    "https://app.ordopro.fr",
   ]
 }
 
@@ -149,9 +172,9 @@ variable "lambda_python_runtime" {
 }
 
 locals {
-  image_name        = "${var.app_name}-${var.environment}"
-  backend_subdomain = "api.${var.domain_name}"
-  frontend_domain   = var.domain_name
+  image_name             = "${var.app_name}-${var.environment}"
+  backend_subdomain      = "api.${var.domain_name}"
+  frontend_domain_prefix = "app"
   ## dynamic environment variables
-  env_templated_mail_domain = local.frontend_domain
+  env_templated_mail_domain = var.domain_name
 }


### PR DESCRIPTION
Update the domain mapping.
- ordopro.fr APEX root to map to the marketing landing page
- app.ordopro.fr to map to the React App hosted via Vercel

The marketing landing page is behind GitHub Action static pages, see: https://github.com/mynotif/website

Also see https://github.com/mynotif/website/pull/1