### PR TITLE
:sparkles: Add admin for Subscription and StripeProduct

### DIFF
--- a/src/nurse/admin.py
+++ b/src/nurse/admin.py
@@ -1,6 +1,13 @@
 from django.contrib import admin
 
-from nurse.models import Nurse, Patient, Prescription, UserOneSignalProfile
+from nurse.models import (
+    Nurse,
+    Patient,
+    Prescription,
+    StripeProduct,
+    Subscription,
+    UserOneSignalProfile,
+)
 
 
 @admin.register(Nurse)
@@ -38,4 +45,22 @@ class UserOneSignalProfileAdmin(admin.ModelAdmin):
     list_display = (
         "user",
         "subscription_id",
+    )
+
+
+@admin.register(StripeProduct)
+class StripeProductAdmin(admin.ModelAdmin):
+    list_display = (
+        "name",
+        "product_id",
+        "monthly_price_id",
+        "annual_price_id",
+    )
+
+
+@admin.register(Subscription)
+class SubscriptionAdmin(admin.ModelAdmin):
+    list_display = (
+        "user",
+        "is_active",
     )

--- a/src/nurse/views.py
+++ b/src/nurse/views.py
@@ -271,6 +271,7 @@ class AdminNotificationView(APIView):
 
 
 class SubscriptionViewSet(viewsets.ModelViewSet):
+    stripe.api_key = settings.STRIPE_API_KEY
     queryset = Subscription.objects.all()
     serializer_class = SubscriptionSerializer
 
@@ -313,7 +314,10 @@ class SubscriptionViewSet(viewsets.ModelViewSet):
 
             headers = self.get_success_headers(serializer.data)
             return Response(
-                {"sessionId": checkout_session.id},
+                {
+                    "sessionId": checkout_session.id,
+                    "checkout_url": checkout_session.url,
+                },
                 status=status.HTTP_201_CREATED,
                 headers=headers,
             )

--- a/src/tests/nurse/test_views.py
+++ b/src/tests/nurse/test_views.py
@@ -1165,6 +1165,9 @@ class TestSubscriptionViewSet:
         response = client.post(self.create_url, data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data["sessionId"] == "session_id_example"
+        assert (
+            response.data["checkout_url"] == "https://checkout.stripe.com/pay/example"
+        )
 
     @patch("nurse.views.stripe.checkout.Session.create")
     @patch("nurse.views.StripeProduct.objects.get")


### PR DESCRIPTION
 This update adds administration classes for Subscription and StripeProduct templates to the `nurse/admin.py` file.
    
    Changes include:
    
    1. Addition of the `StripeProductAdmin` class to manage the display and editing of Stripe products in the admin.
    2. Addition of the `SubscriptionAdmin` class to manage the display and editing of subscriptions in the admin.
    3. Updated `views.py` file to use Stripe API key from configuration parameters.
    4. Added a new `checkout_url` field in the subscription creation response to return the Stripe checkout URL.
    5. Updated unit tests to check the new response with the checkout URL.