### PR TITLE
:bricks: Terraform the prescription s3 bucket

### DIFF
--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,6 @@
+resource "aws_s3_bucket" "prescription" {
+  bucket = "mynotif-prescription"
+  tags = {
+    Name = "Prescription files"
+  }
+}


### PR DESCRIPTION
This bucket is used to store prescription file uploads. The bucket already exited as it was created manually, but it's now mapped with Terraform, fixes #62