### PR TITLE
:recycle: Centralize and reuse test fixtures with conftest.py

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,57 @@
+import pytest
+from django.contrib.auth.models import User
+from django.urls.base import reverse_lazy
+from rest_framework import status
+from rest_framework.test import APIClient
+
+PASSWORD = "password1"
+FIRSTNAME = "John"
+LASTNAME = "Doe"
+EMAIL = "johndoe@example.fr"
+USERNAME = EMAIL
+EMAIL_HOST_USER = "support@ordopro.fr"
+
+
+@pytest.fixture
+def user(db):
+    """Creates and yields a new user."""
+    user = User.objects.create(
+        username=USERNAME, first_name=FIRSTNAME, last_name=LASTNAME, email=EMAIL
+    )
+    user.set_password(PASSWORD)
+    user.save()
+    yield user
+    user.delete()
+
+
+def authenticate_client_with_token(client, email, password):
+    """Authenticates a client using a token and returns it."""
+    # void previous credentials to avoid "Invalid token" errors
+    client.credentials()
+    response = client.post(
+        reverse_lazy("v2:api_token_auth"),
+        {"email": email, "password": password},
+        format="json",
+    )
+    assert response.status_code == status.HTTP_200_OK
+    token = response.data["token"]
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
+    return client
+
+
+@pytest.fixture
+def staff_user(user):
+    """Creates and yields a staff user."""
+    user.is_staff = True
+    user.save()
+    yield user
+
+
+@pytest.fixture
+def authenticated_client(user):
+    """Authenticates the user via token and yields it."""
+    client = APIClient()
+    client = authenticate_client_with_token(client, user.email, PASSWORD)
+    yield client
+    # invalidates credentials
+    client.credentials()

--- a/src/tests/nurse/test_views.py
+++ b/src/tests/nurse/test_views.py
@@ -17,29 +17,19 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from nurse.models import Nurse, Patient, Prescription, UserOneSignalProfile
-
-PASSWORD = "password1"
-FIRSTNAME = "John"
-LASTNAME = "Doe"
-EMAIL = "johndoe@example.fr"
-USERNAME = EMAIL
-EMAIL_HOST_USER = "support@ordopro.fr"
+from tests.conftest import (
+    EMAIL,
+    EMAIL_HOST_USER,
+    FIRSTNAME,
+    LASTNAME,
+    PASSWORD,
+    USERNAME,
+    authenticate_client_with_token,
+)
 
 
 def patch_notify():
     return mock.patch("nurse.views.notify")
-
-
-@pytest.fixture
-def user(db):
-    """Creates and yields a new user."""
-    user = User.objects.create(
-        username=USERNAME, first_name=FIRSTNAME, last_name=LASTNAME, email=EMAIL
-    )
-    user.set_password(PASSWORD)
-    user.save()
-    yield user
-    user.delete()
 
 
 @pytest.fixture
@@ -52,39 +42,6 @@ def user2(db):
     user.save()
     yield user
     user.delete()
-
-
-@pytest.fixture
-def staff_user(user):
-    """Creates and yields a staff user."""
-    user.is_staff = True
-    user.save()
-    yield user
-
-
-def authenticate_client_with_token(client, email, password):
-    """Authenticates a client using a token and returns it."""
-    # void previous credentials to avoid "Invalid token" errors
-    client.credentials()
-    response = client.post(
-        reverse_lazy("v2:api_token_auth"),
-        {"email": email, "password": password},
-        format="json",
-    )
-    assert response.status_code == status.HTTP_200_OK
-    token = response.data["token"]
-    client.credentials(HTTP_AUTHORIZATION=f"Token {token}")
-    return client
-
-
-@pytest.fixture
-def authenticated_client(user):
-    """Authenticates the user via token and yields it."""
-    client = APIClient()
-    client = authenticate_client_with_token(client, user.email, PASSWORD)
-    yield client
-    # invalidates credentials
-    client.credentials()
 
 
 @pytest.fixture


### PR DESCRIPTION
- Moved shared test fixtures (`user`, `staff_user`, `authenticated_client`, etc.) to a dedicated `conftest.py` file.

- Removed duplicate definitions of these fixtures from `test_views.py`.

- Ensured consistent import and reuse of fixtures and utility functions across tests.