### PR TITLE
:sparkles: Add to cancel a subscription

### DIFF
--- a/src/payment/urls.py
+++ b/src/payment/urls.py
@@ -4,6 +4,7 @@ from rest_framework import routers
 from payment.views import (
     SubscriptionCancelView,
     SubscriptionSuccessView,
+    SubscriptionUserCancelView,
     SubscriptionViewSet,
 )
 
@@ -25,6 +26,11 @@ urlpatterns = [
         "subscriptions/cancel/",
         SubscriptionCancelView.as_view(),
         name="subscription-cancel",
+    ),
+    path(
+        "subscriptions/user/cancel/",
+        SubscriptionUserCancelView.as_view(),
+        name="subscription-user-cancel",
     ),
     path("stripe/webhook/", webhooks.stripe_webhook, name="stripe-webhook"),
 ]


### PR DESCRIPTION
- Added endpoint for user subscription cancellation (`SubscriptionUserCancelView`).
- Update routes to include the new user subscription cancellation endpoint.
- Created a test to verify that user subscription cancellation works.
- Simulated Stripe behavior with a mock in tests to avoid real API calls.