### PR TITLE
:goal_net: Custom exception handlers

### DIFF
--- a/src/main/urls.py
+++ b/src/main/urls.py
@@ -31,6 +31,9 @@ from nurse.urls import router as nurse_router
 
 from . import views as main_views
 
+handler400 = "rest_framework.exceptions.bad_request"
+handler500 = "rest_framework.exceptions.server_error"
+
 router = routers.DefaultRouter()
 router.registry.extend(nurse_router.registry)
 
@@ -40,6 +43,12 @@ v1_urlpatterns = [
     path("auth/", include(("djoser.urls", "auth"), namespace="auth")),
     path("", include("nurse.urls"), name="nurse"),
     path("api-token-auth/", obtain_auth_token, name="api_token_auth"),
+    path("error-400/", main_views.Error400View.as_view(), name="error_400"),
+    path("api-error-400/", main_views.Error400APIView.as_view(), name="api_error_400"),
+    path("error-404/", main_views.Error404View.as_view(), name="error_404"),
+    path("api-error-404/", main_views.Error404APIView.as_view(), name="api_error_404"),
+    path("error-500/", main_views.Error500View.as_view(), name="error_500"),
+    path("api-error-500/", main_views.Error500APIView.as_view(), name="api_error_500"),
 ]
 
 v2_urlpatterns = [

--- a/src/main/views.py
+++ b/src/main/views.py
@@ -1,9 +1,12 @@
 import os
 
-from django.http import JsonResponse
+from django.core.exceptions import BadRequest
+from django.http import Http404, JsonResponse
+from django.views import View
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
+from rest_framework.views import APIView
 
 from main.serializers import CustomAuthTokenSerializer
 
@@ -22,3 +25,61 @@ class CustomObtainAuthToken(ObtainAuthToken):
     """
 
     serializer_class = CustomAuthTokenSerializer
+
+
+class ErrorViewMixin:
+    """Mixin to handle error-raising patterns for views."""
+
+    exception_class = Exception
+    exception_message = "An error occurred."
+
+    def raise_exception(self):
+        raise self.exception_class(self.exception_message)
+
+    def get(self, request):
+        self.raise_exception()
+
+
+class Error400View(ErrorViewMixin, View):
+    """Raise a 400 ValidationError while inheriting the regular Django View."""
+
+    exception_class = BadRequest
+    exception_message = "This is a bad request (400) for testing."
+
+
+class Error400APIView(ErrorViewMixin, APIView):
+    """Raise a 400 ValidationError while inheriting the DRF APIView."""
+
+    permission_classes = [AllowAny]
+    exception_class = BadRequest
+    exception_message = "This is a bad request (400) for testing."
+
+
+class Error404View(ErrorViewMixin, View):
+    """Raise a regular django.http.Http404 while inheriting the regular Django View."""
+
+    exception_class = Http404
+    exception_message = "This is an uncaught 404 exception for testing."
+
+
+class Error404APIView(ErrorViewMixin, APIView):
+    """Raise a regular django.http.Http404 while inheriting the DRF APIView."""
+
+    permission_classes = [AllowAny]
+    exception_class = Http404
+    exception_message = "This is an uncaught 404 exception for testing."
+
+
+class Error500View(ErrorViewMixin, View):
+    """Raise an uncaught exception while inheriting the regular Django View."""
+
+    exception_class = ValueError
+    exception_message = "This is an uncaught exception (500) for testing."
+
+
+class Error500APIView(ErrorViewMixin, APIView):
+    """Raise an uncaught exception while inheriting the DRF APIView."""
+
+    permission_classes = [AllowAny]
+    exception_class = ValueError
+    exception_message = "This is an uncaught exception (500) for testing."

--- a/src/tests/main/test_views.py
+++ b/src/tests/main/test_views.py
@@ -31,3 +31,117 @@ class TestVersion:
             response = client.get(self.url)
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {"version": expected}
+
+
+class TestError400View:
+    url = "/api/v1/error-400/"
+
+    def test_endpoint(self):
+        assert self.url == reverse_lazy("v1:error_400")
+
+    def test_400(self, client):
+        """
+        Raising a `django.core.exceptions.BadRequest` without implementing
+        `rest_framework.views.APIView` should still return a `JsonResponse`.
+        """
+        response = client.get(self.url)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {"error": "Bad Request (400)"}
+
+
+class TestError400APIView:
+    url = "/api/v1/api-error-400/"
+
+    def test_endpoint(self):
+        assert self.url == reverse_lazy("v1:api_error_400")
+
+    def test_api_400(self, client):
+        """
+        Views raising a `django.core.exceptions.BadRequest` should return a
+        `JsonResponse` as long as they implement the `rest_framework.views.APIView`.
+        """
+        response = client.get(self.url)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {"error": "Bad Request (400)"}
+
+
+class TestError404View:
+    url = "/api/v1/error-404/"
+
+    def test_endpoint(self):
+        assert self.url == reverse_lazy("v1:error_404")
+
+    def test_404(self, client):
+        """
+        Raising a `django.http.Http404` without implementing
+        `rest_framework.views.APIView` should return an HTML response.
+        """
+        response = client.get(self.url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.content.decode("utf-8").split("\n") == [
+            "",
+            "<!doctype html>",
+            '<html lang="en">',
+            "<head>",
+            "  <title>Not Found</title>",
+            "</head>",
+            "<body>",
+            "  <h1>Not Found</h1>"
+            + "<p>The requested resource was not found on this server.</p>",
+            "</body>",
+            "</html>",
+            "",
+        ]
+
+
+class TestError404APIView:
+    url = "/api/v1/api-error-404/"
+
+    def test_endpoint(self):
+        assert self.url == reverse_lazy("v1:api_error_404")
+
+    def test_api_404(self, client):
+        """
+        Views raising a `django.http.Http404` should return a `JsonResponse` as long as
+        they implement the `rest_framework.views.APIView`.
+        """
+        response = client.get(self.url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.data == {
+            "detail": "This is an uncaught 404 exception for testing."
+        }
+
+
+class TestError500View:
+    url = "/api/v1/error-500/"
+
+    def test_endpoint(self):
+        assert self.url == reverse_lazy("v1:error_500")
+
+    def test_500(self, client):
+        """
+        Raising an exception without implementing `rest_framework.views.APIView`
+        should still return a `JsonResponse` thanks to the urls `handler500`
+        `rest_framework.exceptions.server_error`.
+        """
+        client.raise_request_exception = False
+        response = client.get(self.url)
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json() == {"error": "Server Error (500)"}
+
+
+class TestError500APIView:
+    url = "/api/v1/api-error-500/"
+
+    def test_endpoint(self):
+        assert self.url == reverse_lazy("v1:api_error_500")
+
+    def test_api_500(self, client):
+        """
+        Raising an uncaught exception should return a `JsonResponse` for views
+        implementing `rest_framework.views.APIView`.
+        """
+        client.raise_request_exception = False
+        response = client.get(self.url)
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json() == {"error": "Server Error (500)"}


### PR DESCRIPTION
Custom exception handlers for 400 and 500.
Leverage the custom exception handlers from Django Rest Framework to always return a JSON response.
Not that 404 exceptions should also return a JSON response as long as we implement the DRF `APIView`.
Alternatively we could have used the `REST_FRAMEWORK.EXCEPTION_HANDLER`, but using the implementation provided by Django Rest Framework for both `handler500` and `handler400` seemed more straightforward.

Find out more:
https://www.django-rest-framework.org/api-guide/exceptions/