### PR TITLE
:construction_worker: Make sure Terraform is available

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ jobs:
         with:
           python-version: 3.13
       - run: make virtualenv/test
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
       - run: make lint
       - run: make unittest
       - name: Upload coverage to Codecov


### PR DESCRIPTION
This is needed for the Terraform linting via `terraform fmt`. The error was:
```
terraform -chdir=terraform fmt -recursive -diff -check
make: terraform: No such file or directory
```
See: https://github.com/mynotif/mynotif-backend/actions/runs/12894486549/job/35953235371?pr=215