### PR TITLE
:sparkles: add FRONTEND_URL env var for dynamic Stripe redirection URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ AWS_SECRET_ACCESS_KEY=
 STRIPE_PUBLIC_KEY=
 STRIPE_API_KEY=
 STRIPE_WEBHOOK_SECRET=
+
+# Frontend URL, used for the Stripe success/cancel redirect
+FRONTEND_URL=http://localhost:3000

--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -252,3 +252,6 @@ if SENTRY_DSN := os.environ.get("SENTRY_DSN"):
 STRIPE_PUBLIC_KEY = os.environ.get("STRIPE_PUBLIC_KEY", "")
 STRIPE_API_KEY = os.environ.get("STRIPE_API_KEY", "")
 STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
+
+# Frontend URL, used for the Stripe success/cancel redirect
+FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:3000")

--- a/src/payment/urls.py
+++ b/src/payment/urls.py
@@ -1,12 +1,7 @@
 from django.urls import include, path
 from rest_framework import routers
 
-from payment.views import (
-    SubscriptionCancelView,
-    SubscriptionSuccessView,
-    SubscriptionUserCancelView,
-    SubscriptionViewSet,
-)
+from payment.views import SubscriptionUserCancelView, SubscriptionViewSet
 
 from . import webhooks
 
@@ -17,16 +12,6 @@ app_name = "payment"
 
 urlpatterns = [
     path("", include(router.urls)),
-    path(
-        "subscriptions/success/",
-        SubscriptionSuccessView.as_view(),
-        name="subscription-success",
-    ),
-    path(
-        "subscriptions/cancel/",
-        SubscriptionCancelView.as_view(),
-        name="subscription-cancel",
-    ),
     path(
         "subscriptions/user/cancel/",
         SubscriptionUserCancelView.as_view(),

--- a/src/payment/views.py
+++ b/src/payment/views.py
@@ -1,7 +1,6 @@
 import stripe
 from django.conf import settings
 from django.shortcuts import get_object_or_404
-from django.urls import reverse
 from rest_framework import status, viewsets
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -39,12 +38,8 @@ class SubscriptionViewSet(viewsets.ModelViewSet):
             mode="subscription",
             billing_address_collection="required",
             currency="eur",
-            success_url=request.build_absolute_uri(
-                reverse("v1:payment:subscription-success")
-            ),
-            cancel_url=request.build_absolute_uri(
-                reverse("v1:payment:subscription-cancel")
-            ),
+            success_url=f"{settings.FRONTEND_URL}/success?checkout=true",
+            cancel_url=f"{settings.FRONTEND_URL}/cancel?checkout=true",
             metadata={
                 "user_id": user.id,
                 "product_name": product.name,
@@ -95,37 +90,3 @@ class SubscriptionUserCancelView(APIView):
             {"message": "Subscription canceled successfully"},
             status=status.HTTP_200_OK,
         )
-
-
-class SubscriptionSuccessView(APIView):
-    """
-    Handles the redirection after a successful payment.
-
-    This endpoint corresponds to the success_url defined when creating
-    a Stripe checkout session. Stripe redirects the user here when the
-    payment is successful, confirming the subscription action with a
-    200 OK status.
-    """
-
-    def get(self, request, *args, **kwargs):
-        return Response(
-            {"message": "Subscription successful"}, status=status.HTTP_200_OK
-        )
-
-
-class SubscriptionCancelView(APIView):
-    """
-    Handles the redirection after a payment failure or cancelation.
-
-    This endpoint corresponds to the cancel_url defined
-    when creating a Stripe Checkout session.
-    Stripe redirects the user here
-    if the payment is not completed
-    (i.e., the user either cancels the payment or the payment fails for any reason).
-    This confirms that the payment process was interrupted or
-    not successfully completed,
-    and a 200 OK status is returned to acknowledge the cancelation.
-    """
-
-    def get(self, request, *args, **kwargs):
-        return Response({"message": "Subscription canceled"}, status=status.HTTP_200_OK)

--- a/src/tests/payment/test_views.py
+++ b/src/tests/payment/test_views.py
@@ -145,29 +145,3 @@ class TestSubscriptionUserCancelView:
 
         subscription.refresh_from_db()
         assert subscription.cancel_at_period_end is False
-
-
-@pytest.mark.django_db
-class TestSubscriptionSuccessView:
-    url = reverse_lazy("v1:payment:subscription-success")
-
-    def test_endpoint(self):
-        assert self.url == "/api/v1/payment/subscriptions/success/"
-
-    def test_subscription_success_view(self, client):
-        response = client.get(self.url)
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data == {"message": "Subscription successful"}
-
-
-@pytest.mark.django_db
-class TestSubscriptionCancelView:
-    url = reverse_lazy("v1:payment:subscription-cancel")
-
-    def test_endpoint(self):
-        assert self.url == "/api/v1/payment/subscriptions/cancel/"
-
-    def test_subscription_cancel_view(self, client):
-        response = client.get(self.url)
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data == {"message": "Subscription canceled"}


### PR DESCRIPTION
  - Add FRONTEND_URL environment variable with localhost default
    - Replace backend success/cancel endpoints with frontend URLs
    - Remove unused SubscriptionSuccessView and SubscriptionCancelView
    - Update related tests
    - Add FRONTEND_URL to .env.example
