### PR TITLE
:sparkles: Add Stripe and frontend URL configuration to AppRunner

### DIFF
--- a/terraform/apprunner.tf
+++ b/terraform/apprunner.tf
@@ -51,6 +51,11 @@ resource "aws_apprunner_service" "backend" {
           # OneSignal
           ONESIGNAL_APP_ID  = data.aws_ssm_parameter.onesignal_api_id.value
           ONESIGNAL_API_KEY = data.aws_ssm_parameter.onesignal_api_key.value
+          # Stripe
+          STRIPE_API_KEY        = data.aws_ssm_parameter.stripe_api_key.value
+          STRIPE_WEBHOOK_SECRET = data.aws_ssm_parameter.stripe_webhook_secret.value
+          # Frontend URL
+          FRONTEND_URL = var.frontend_url
         }
       }
       image_repository_type = "ECR"

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -61,3 +61,12 @@ data "aws_ssm_parameter" "notify_username" {
 data "aws_ssm_parameter" "notify_password" {
   name = "${var.app_name}-notify-password-${var.environment}"
 }
+
+# Stripe
+data "aws_ssm_parameter" "stripe_api_key" {
+  name = "${var.app_name}-stripe-api-key-${var.environment}"
+}
+
+data "aws_ssm_parameter" "stripe_webhook_secret" {
+  name = "${var.app_name}-stripe-webhook-secret-${var.environment}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -164,6 +164,13 @@ variable "env_templated_site_name" {
   default = "MyNotif"
 }
 
+# Frontend URL
+variable "frontend_url" {
+  type        = string
+  description = "Frontend URL for Stripe redirects"
+  default     = "https://app.ordopro.fr"
+}
+
 ## Lambda configuration
 variable "lambda_python_runtime" {
   description = "AWS Lambda Python runtime version"


### PR DESCRIPTION
- Added Stripe environment variables (STRIPE_API_KEY, STRIPE_WEBHOOK_SECRET) to the AppRunner service configuration.

- Added frontend_url variable to support Stripe redirects.

- Created SSM parameter data sources for Stripe API key and webhook secret.