### PR TITLE
:sparkles: Limit patient & prescription creation for free users

### DIFF
--- a/src/main/settings.py
+++ b/src/main/settings.py
@@ -254,3 +254,10 @@ STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET", "")
 
 # Frontend URL, used for the Stripe success/cancel redirect
 FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:3000")
+
+# Maximum number of free patients and prescriptions
+# these values need to be in sync until we implement the single source of truth
+# https://github.com/mynotif/mynotif-frontend/blob/3d1c858/src/hook/patientManagement.ts#L4
+# https://github.com/mynotif/mynotif-frontend/blob/3d1c858/src/hook/prescriptionManagement.ts#L4
+FREE_PATIENT_LIMIT = 15
+FREE_PRESCRIPTION_LIMIT = 15

--- a/src/nurse/models.py
+++ b/src/nurse/models.py
@@ -1,7 +1,10 @@
+import contextlib
 from datetime import datetime, timedelta
 
 from django.contrib.auth.models import User
 from django.db import models
+
+from payment.models import Subscription
 
 
 def make_street_field():
@@ -51,6 +54,16 @@ class Nurse(models.Model):
 
     def __str__(self):
         return str(self.user)
+
+    def get_active_subscription(self):
+        """Returns the active subscription"""
+        """for the nurse's user if it exists, otherwise None."""
+        with contextlib.suppress(Subscription.DoesNotExist):
+            return Subscription.objects.get(user=self.user, active=True)
+
+    def has_active_subscription(self):
+        """Returns True if the nurse has an active subscription."""
+        return self.get_active_subscription() is not None
 
 
 class PrescriptionManager(models.Manager):

--- a/src/nurse/utils/constants.py
+++ b/src/nurse/utils/constants.py
@@ -1,0 +1,4 @@
+FREE_LIMIT_MESSAGE = (
+    "You have reached the maximum number of patients or subscriptions "
+    "allowed under the free subscription plan"
+)


### PR DESCRIPTION
- Enforce a limit of 15 patients and 15 prescriptions for users without an active subscription.
- Return a 403 error when the limit is reached.
- Ensure subscribed users have no restrictions.